### PR TITLE
fix combined/pom.xml processing in ant task

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -63,7 +63,7 @@
                 <replace dir="site" token="target/mycompany" value="target/${company-name}" summary="yes" excludes="target/" />
                 <replace file="site/src/main/webapp/WEB-INF/web.xml" token="mycompany" value="${company-name}" summary="yes" excludes="target/" />
                 <replace file="site/pom.xml" token="mycompany" value="${company-name}" summary="yes" excludes="target/" />
-                <replace file="combined/pom.xml" token="mycompany" value="${company-name}" summary="yes" excludes="target/" />
+                <replace file="combined/pom.xml" token="com.mycompany" value="${maven-group}" summary="yes" excludes="target/" />
             </then>
         </if>
     </target>


### PR DESCRIPTION
only the 'mycompany' token was replaced in combined/pom.xml which produced maven errors ... so fixed this to search for 'com.mycompany' token and replace it with the maven-module variable
