### PR TITLE
Fix bug where running change identifiers did not work

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,23 +46,18 @@
                 <echo message="${maven-group}" />
                 <echo message="${company-name}" />
                 <!-- Move the required files / directories to their new homes -->
-                <move file="admin/src/main/resources/com/mycompany/gwt/mycompanyAdmin.gwt.xml" tofile="admin/src/main/resources/${company-tld}/${company-name}/gwt/${company-name}Admin.gwt.xml" />
-                <move file="admin/src/main/resources/com/mycompany" tofile="admin/src/main/resources/${company-tld}/${company-name}" />
                 <move file="site/src/main/java/com/mycompany" tofile="site/src/main/java/${company-tld}/${company-name}" />
-                <move file="admin/src/main/java/com/mycompany" tofile="admin/src/main/java/${company-tld}/${company-name}" />
                 <!-- Replace the appropriate tokens -->
                 <replace file="pom.xml" token="com.mycompany" value="${maven-group}" summary="yes" excludes="target/" />
                 <replace dir="admin" token="com.mycompany.gwt.mycompanyAdmin" value="${maven-group}.gwt.${company-name}Admin" summary="yes" excludes="target/" />
                 <replace dir="admin" token="mycompany-admin" value="${company-name}-admin" summary="yes" excludes="target/" />
                 <replace dir="admin" token="com.mycompany" value="${maven-group}" summary="yes" excludes="target/" />
-                <replace dir="combined" token="com.mycompany.gwt.mycompanyAdmin" value="${maven-group}.gwt.${company-name}Admin" summary="yes" excludes="target/" />
                 <replace dir="core" token="com.mycompany" value="${maven-group}" summary="yes" excludes="target/" />
                 <replace dir="site" token="com.mycompany" value="${maven-group}" summary="yes" excludes="target/" />
                 <replace dir="site" token="mycompany-site" value="${company-name}-site" summary="yes" excludes="target/" />
                 <replace dir="site" token="target/mycompany" value="target/${company-name}" summary="yes" excludes="target/" />
                 <replace file="site/src/main/webapp/WEB-INF/web.xml" token="mycompany" value="${company-name}" summary="yes" excludes="target/" />
                 <replace file="site/pom.xml" token="mycompany" value="${company-name}" summary="yes" excludes="target/" />
-                <replace file="combined/pom.xml" token="mycompany" value="${company-name}" summary="yes" excludes="target/" />
             </then>
         </if>
     </target>


### PR DESCRIPTION
Because the admin module has change, running the change-identifiers ant task would fail. Removing these lines allows it to run properly again
