### PR TITLE
adding latlontype fieldtype and necessary dynamicfields for geolocation search/facet

### DIFF
--- a/site/src/main/resources/schema.xml
+++ b/site/src/main/resources/schema.xml
@@ -32,6 +32,12 @@
         <dynamicField name="*_tl" type="tlong" indexed="true" stored="false" />
         <dynamicField name="*_td" type="tdouble" indexed="true" stored="false" />
         <dynamicField name="*_tdt" type="tdate" indexed="true" stored="false" />
+
+        <!-- Both field types required for geolocation searches. First stores the
+            lat and lon components for the "coordinate" FieldType. Second stores
+            the coordinate. -->
+        <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="false"/>
+        <dynamicField name="*_c"  type="coordinate" indexed="true" stored="false"/> 
     </fields>
     
     <uniqueKey>id</uniqueKey>
@@ -87,6 +93,9 @@
                 <filter class="solr.LowerCaseFilterFactory" />
             </analyzer>
         </fieldType>
+
+        <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
+        <fieldType name="coordinate" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
     </types>
 </schema>


### PR DESCRIPTION
this adds a LatLonType fieldType and two dynamicFields for geolocation search and faceting. The *_coordinate dynamic is not used directly, but is required by solr to store the latitude and longitude. BLC users should instead use *_c for their fields.

To use this I extended Product with a String field called location. Within the location field I put a lat/long pair in the format required by solr (e.g. "32.946467,-96.786969"). I then inserted an entry in BLC_FIELD with a facet_field_type of 'c' and and entry in BLC_FIELD_SEARCH_TYPES with a searchable_field_type of 'c'.

Use of this also required a version of the framework built with the FieldType in the BroadleafCommerce pull request [#1067](https://github.com/BroadleafCommerce/BroadleafCommerce/pull/1067).
