### PR TITLE
Fix #164 - NPE when empty address form is submitted

### DIFF
--- a/site/src/main/webapp/WEB-INF/templates/account/manageCustomerAddresses.html
+++ b/site/src/main/webapp/WEB-INF/templates/account/manageCustomerAddresses.html
@@ -33,7 +33,7 @@
             <div class="form30 margin20">
                 <label for="phone">Phone</label>
                 <span class="error_spacer" th:if="${#fields.hasErrors('address.firstName') or #fields.hasErrors('address.lastName')}">error</span>
-                <input type="tel" id="address.phonePrimary" name="address.phonePrimary" th:value="*{address.phonePrimary.phoneNumber}" class="field30 cloneable" />
+                <input type="tel" id="address.phonePrimary" name="address.phonePrimary" th:field="*{address.phonePrimary.phoneNumber}" class="field30 cloneable" />
             </div>
             <div class="form50">
                 <label for="address1">Address</label>


### PR DESCRIPTION
By using th:field instead of th:value CustomerAddressForm#address#phonePrimary
is no longer nulled when submitted. Fix for #164.
