### PR TITLE
Fix broken images when product doesn't have primary media

### DIFF
--- a/site/src/main/webapp/WEB-INF/templates/cart/partials/cartProductsTable.html
+++ b/site/src/main/webapp/WEB-INF/templates/cart/partials/cartProductsTable.html
@@ -16,7 +16,7 @@
                     <img th:if="${optionValue.attributeValue == item.sku.skuMedia['alt1']?.tags}" blc:src="@{*{sku.skuMedia['alt1'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                     <img th:if="${optionValue.attributeValue == item.sku.skuMedia['alt2']?.tags}" blc:src="@{*{sku.skuMedia['alt2'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                 </th:block>
-                <img th:if="*{#lists.isEmpty(sku.productOptionValues)}" blc:src="@{*{sku.skuMedia['primary']?.url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
+                <img th:if="*{#lists.isEmpty(sku.productOptionValues) and sku.skuMedia['primary'] != null}" blc:src="@{*{sku.skuMedia['primary']?.url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
             </td>
             <td class="name">
                 <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:href="@{*{product.url}}" th:utext="*{product.name}"></a>

--- a/site/src/main/webapp/WEB-INF/templates/checkout/confirmation.html
+++ b/site/src/main/webapp/WEB-INF/templates/checkout/confirmation.html
@@ -32,7 +32,7 @@
                         <img th:if="${optionValue.attributeValue == item.sku.skuMedia['alt1']?.tags}" blc:src="@{*{sku.skuMedia['alt1'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                         <img th:if="${optionValue.attributeValue == item.sku.skuMedia['alt2']?.tags}" blc:src="@{*{sku.skuMedia['alt2'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                     </th:block>
-                    <img th:if="*{#lists.isEmpty(sku.productOptionValues)}" blc:src="@{*{sku.skuMedia['primary'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
+                    <img th:if="*{#lists.isEmpty(sku.productOptionValues) and sku.skuMedia['primary'] != null}" blc:src="@{*{sku.skuMedia['primary'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                 </td>
                 <td align="left">
                     <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:href="@{*{product.url}}" th:utext="*{product.name}"></a>

--- a/site/src/main/webapp/WEB-INF/templates/checkout/partials/orderSummary.html
+++ b/site/src/main/webapp/WEB-INF/templates/checkout/partials/orderSummary.html
@@ -24,7 +24,7 @@
                     <img th:if="${optionValue.attributeValue == item.sku.skuMedia['alt1']?.tags}" blc:src="@{*{sku.skuMedia['alt1'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                     <img th:if="${optionValue.attributeValue == item.sku.skuMedia['alt2']?.tags}" blc:src="@{*{sku.skuMedia['alt2'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                 </th:block>
-                <img th:if="*{#lists.isEmpty(sku.productOptionValues)}" blc:src="@{*{sku.skuMedia['primary'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
+                <img th:if="*{#lists.isEmpty(sku.productOptionValues) and sku.skuMedia['primary'] != null}" blc:src="@{*{sku.skuMedia['primary'].url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
             </td>
             <td align="left">
                 <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:href="@{*{product.url}}" th:utext="*{product.name}"></a>


### PR DESCRIPTION
Fixes #177, BroadleafCommerce/QA#631

When going through the checkout process with a product that doesn't have primary media set, there will be no image shown now instead of a broken image.
