### PR TITLE
Fixed the request mapping consume expressions in the API endpoints

### DIFF
--- a/site/src/main/java/com/mycompany/api/endpoint/cart/CartEndpoint.java
+++ b/site/src/main/java/com/mycompany/api/endpoint/cart/CartEndpoint.java
@@ -72,7 +72,8 @@ public class CartEndpoint extends com.broadleafcommerce.rest.api.endpoint.order.
         return super.findCartById(request, cartId);
     }
 
-    @RequestMapping(value = "/{cartId}/item", method = RequestMethod.POST)
+    @RequestMapping(value = "/{cartId}/item", method = RequestMethod.POST,
+            consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE })
     public OrderWrapper addItemToOrder(HttpServletRequest request,
                                           @PathVariable("cartId") Long cartId,
                                           @RequestParam(value = "priceOrder", required = false, defaultValue = "true") Boolean priceOrder,

--- a/site/src/main/java/com/mycompany/api/endpoint/cart/FulfillmentEndpoint.java
+++ b/site/src/main/java/com/mycompany/api/endpoint/cart/FulfillmentEndpoint.java
@@ -44,8 +44,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(value = "/shipping/",
-    produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE},
-    consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class FulfillmentEndpoint extends com.broadleafcommerce.rest.api.endpoint.order.FulfillmentEndpoint {
 
     @Override
@@ -85,7 +84,8 @@ public class FulfillmentEndpoint extends com.broadleafcommerce.rest.api.endpoint
     }
     
     @Override
-    @RequestMapping(value = "{cartId}/{fulfillmentGroupId}/address", method = RequestMethod.PUT)
+    @RequestMapping(value = "{cartId}/{fulfillmentGroupId}/address", method = RequestMethod.PUT,
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     public FulfillmentGroupWrapper updateFulfillmentGroupAddress(HttpServletRequest request,
                                                                  @PathVariable("fulfillmentGroupId") Long fulfillmentGroupId,
                                                                  @PathVariable("cartId") Long cartId,

--- a/site/src/main/java/com/mycompany/api/endpoint/cart/OrderHistoryEndpoint.java
+++ b/site/src/main/java/com/mycompany/api/endpoint/cart/OrderHistoryEndpoint.java
@@ -39,8 +39,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(value = "/orders",
-    produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE},
-    consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
 public class OrderHistoryEndpoint extends com.broadleafcommerce.rest.api.endpoint.order.OrderHistoryEndpoint {
 
     @Override


### PR DESCRIPTION
Removed consumes expressions from controller level request mappings and instead applied it to all endpoints that have a `@RequestBody`

Related to:
https://github.com/BroadleafCommerce/API/pull/26